### PR TITLE
Cadastrar GitHub IDs nos Models

### DIFF
--- a/src/controllers/StudentController.ts
+++ b/src/controllers/StudentController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import * as yup from 'yup';
 
+import GetUserService from '../services/GetUserService';
 import GetProfileService from '../services/GetProfileService';
 import GetLanguagesService from '../services/GetLanguagesService';
 import CreateStudentService from '../services/CreateStudentService';
@@ -16,14 +17,18 @@ class StudentController {
     const { github_login } = request.body;
     const { teacher } = request;
 
-    const getProfileService = new GetProfileService();
-    const { avatar_url } = await getProfileService.execute(github_login);
+    const getProfile = new GetProfileService();
+    const { avatar_url } = await getProfile.execute(github_login);
 
-    const getLanguagesService = new GetLanguagesService();
-    const { top_language } = await getLanguagesService.execute(github_login);
+    const getLanguages = new GetLanguagesService();
+    const { top_language } = await getLanguages.execute(github_login);
+
+    const getUser = new GetUserService();
+    const { github_id } = await getUser.execute({ username: github_login });
 
     const createStudentService = new CreateStudentService();
     const student = await createStudentService.execute({
+      github_id,
       github_login,
       avatar_url,
       teacher_id: teacher.id,

--- a/src/controllers/TeacherController.ts
+++ b/src/controllers/TeacherController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import * as yup from 'yup';
 
+import GetUserService from '../services/GetUserService';
 import CreateTeacherService from '../services/CreateTeacherService';
 
 class TeacherController {
@@ -15,8 +16,12 @@ class TeacherController {
 
     const { github_login, email, password } = request.body;
 
+    const getUser = new GetUserService();
+    const { github_id } = await getUser.execute({ username: github_login });
+
     const createTeacher = new CreateTeacherService();
     const teacher = await createTeacher.execute({
+      github_id,
       email,
       github_login,
       password,

--- a/src/database/migrations/1600909362948-CreateTeachers.ts
+++ b/src/database/migrations/1600909362948-CreateTeachers.ts
@@ -51,7 +51,7 @@ export default class CreateTeachers1600909362948 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('DROP EXTENSION IF EXISTS "uuid-ossp"');
     await queryRunner.dropTable('teachers');
+    await queryRunner.query('DROP EXTENSION IF EXISTS "uuid-ossp"');
   }
 }

--- a/src/database/migrations/1600912090409-CreateRepositories.ts
+++ b/src/database/migrations/1600912090409-CreateRepositories.ts
@@ -55,6 +55,6 @@ export default class CreateRepositories1600912090409
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropTable('respositories');
+    await queryRunner.dropTable('repositories');
   }
 }

--- a/src/database/migrations/1601656934842-AddGithubId.ts
+++ b/src/database/migrations/1601656934842-AddGithubId.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export default class AddGithubId1601656934842 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'teachers',
+      new TableColumn({
+        name: 'github_id',
+        type: 'int2',
+        isNullable: false,
+      }),
+    );
+    await queryRunner.addColumn(
+      'students',
+      new TableColumn({
+        name: 'github_id',
+        type: 'int2',
+        isNullable: false,
+      }),
+    );
+    await queryRunner.addColumn(
+      'repositories',
+      new TableColumn({
+        name: 'github_id',
+        type: 'int2',
+        isNullable: false,
+      }),
+    );
+    await queryRunner.addColumn(
+      'commits',
+      new TableColumn({
+        name: 'sha',
+        type: 'varchar',
+        isNullable: false,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('commits', 'sha');
+    await queryRunner.dropColumn('repositories', 'github_id');
+    await queryRunner.dropColumn('students', 'github_id');
+    await queryRunner.dropColumn('teachers', 'github_id');
+  }
+}

--- a/src/database/migrations/1601656934842-AddGithubId.ts
+++ b/src/database/migrations/1601656934842-AddGithubId.ts
@@ -6,7 +6,7 @@ export default class AddGithubId1601656934842 implements MigrationInterface {
       'teachers',
       new TableColumn({
         name: 'github_id',
-        type: 'int2',
+        type: 'varchar',
         isNullable: false,
       }),
     );
@@ -14,7 +14,7 @@ export default class AddGithubId1601656934842 implements MigrationInterface {
       'students',
       new TableColumn({
         name: 'github_id',
-        type: 'int2',
+        type: 'varchar',
         isNullable: false,
       }),
     );
@@ -22,7 +22,7 @@ export default class AddGithubId1601656934842 implements MigrationInterface {
       'repositories',
       new TableColumn({
         name: 'github_id',
-        type: 'int2',
+        type: 'varchar',
         isNullable: false,
       }),
     );

--- a/src/entities/Repository.ts
+++ b/src/entities/Repository.ts
@@ -1,4 +1,5 @@
 export default interface Repository {
+  id: number;
   name: string;
   full_name: string;
   description: string;

--- a/src/entities/Repository.ts
+++ b/src/entities/Repository.ts
@@ -1,5 +1,5 @@
 export default interface Repository {
-  id: number;
+  id: string;
   name: string;
   full_name: string;
   description: string;

--- a/src/models/Commit.ts
+++ b/src/models/Commit.ts
@@ -39,6 +39,9 @@ class Commit {
   @Column('int2')
   deletions: number;
 
+  @Column('varchar')
+  sha: string;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/models/Repository.ts
+++ b/src/models/Repository.ts
@@ -34,8 +34,8 @@ class Repository {
   @Column('varchar')
   html_url: string;
 
-  @Column('varchar')
-  github_id: string;
+  @Column('int2')
+  github_id: number;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/models/Repository.ts
+++ b/src/models/Repository.ts
@@ -34,8 +34,8 @@ class Repository {
   @Column('varchar')
   html_url: string;
 
-  @Column('int2')
-  github_id: number;
+  @Column('varchar')
+  github_id: string;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/models/Repository.ts
+++ b/src/models/Repository.ts
@@ -34,6 +34,9 @@ class Repository {
   @Column('varchar')
   html_url: string;
 
+  @Column('varchar')
+  github_id: string;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/models/Student.ts
+++ b/src/models/Student.ts
@@ -31,8 +31,8 @@ class Student {
   @Column('varchar')
   top_language: string;
 
-  @Column('int2')
-  github_id: number;
+  @Column('varchar')
+  github_id: string;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/models/Student.ts
+++ b/src/models/Student.ts
@@ -31,6 +31,9 @@ class Student {
   @Column('varchar')
   top_language: string;
 
+  @Column('varchar')
+  github_id: string;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/models/Student.ts
+++ b/src/models/Student.ts
@@ -31,8 +31,8 @@ class Student {
   @Column('varchar')
   top_language: string;
 
-  @Column('varchar')
-  github_id: string;
+  @Column('int2')
+  github_id: number;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/models/Teacher.ts
+++ b/src/models/Teacher.ts
@@ -29,8 +29,8 @@ class Teacher {
   @Column('varchar')
   avatar_url: string;
 
-  @Column('varchar')
-  github_id: string;
+  @Column('int2')
+  github_id: number;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/models/Teacher.ts
+++ b/src/models/Teacher.ts
@@ -29,6 +29,9 @@ class Teacher {
   @Column('varchar')
   avatar_url: string;
 
+  @Column('varchar')
+  github_id: string;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/models/Teacher.ts
+++ b/src/models/Teacher.ts
@@ -29,8 +29,8 @@ class Teacher {
   @Column('varchar')
   avatar_url: string;
 
-  @Column('int2')
-  github_id: number;
+  @Column('varchar')
+  github_id: string;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/services/CreateCommitService.ts
+++ b/src/services/CreateCommitService.ts
@@ -7,6 +7,7 @@ interface Request {
   message: string;
   additions: number;
   deletions: number;
+  sha: string;
 }
 
 class CreateCommitService {
@@ -16,6 +17,7 @@ class CreateCommitService {
     message,
     additions,
     deletions,
+    sha,
   }: Request): Promise<Commit> {
     const commitsRepository = getRepository(Commit);
 
@@ -25,6 +27,7 @@ class CreateCommitService {
       message,
       additions,
       deletions,
+      sha,
     });
     await commitsRepository.save(commit);
 

--- a/src/services/CreateRepositoryService.ts
+++ b/src/services/CreateRepositoryService.ts
@@ -3,7 +3,7 @@ import Repository from '../models/Repository';
 
 interface Request {
   student_id: string;
-  github_id: number;
+  github_id: string;
   name: string;
   full_name: string;
   description: string;

--- a/src/services/CreateRepositoryService.ts
+++ b/src/services/CreateRepositoryService.ts
@@ -3,6 +3,7 @@ import Repository from '../models/Repository';
 
 interface Request {
   student_id: string;
+  github_id: number;
   name: string;
   full_name: string;
   description: string;
@@ -12,6 +13,7 @@ interface Request {
 class CreateRepositoryService {
   async execute({
     student_id,
+    github_id,
     name,
     full_name,
     description,
@@ -21,6 +23,7 @@ class CreateRepositoryService {
 
     const repository = repositoriesRepository.create({
       student_id,
+      github_id,
       name,
       full_name,
       description,

--- a/src/services/CreateStudentService.ts
+++ b/src/services/CreateStudentService.ts
@@ -2,7 +2,7 @@ import { getRepository } from 'typeorm';
 import Student from '../models/Student';
 
 interface Request {
-  github_id: number;
+  github_id: string;
   teacher_id: string;
   github_login: string;
   avatar_url: string;

--- a/src/services/CreateStudentService.ts
+++ b/src/services/CreateStudentService.ts
@@ -2,6 +2,7 @@ import { getRepository } from 'typeorm';
 import Student from '../models/Student';
 
 interface Request {
+  github_id: number;
   teacher_id: string;
   github_login: string;
   avatar_url: string;
@@ -10,6 +11,7 @@ interface Request {
 
 class CreateStudentService {
   async execute({
+    github_id,
     teacher_id,
     github_login,
     avatar_url,
@@ -19,6 +21,7 @@ class CreateStudentService {
 
     const student = studentsRepository.create({
       teacher_id,
+      github_id,
       github_login,
       avatar_url,
       top_language,

--- a/src/services/CreateTeacherService.ts
+++ b/src/services/CreateTeacherService.ts
@@ -5,7 +5,7 @@ import Teacher from '../models/Teacher';
 import GetUserService from './GetUserService';
 
 interface CreateTeacherRequest {
-  github_id: number;
+  github_id: string;
   email: string;
   github_login: string;
   password: string;

--- a/src/services/CreateTeacherService.ts
+++ b/src/services/CreateTeacherService.ts
@@ -27,7 +27,9 @@ class CreateTeacherService {
     }
 
     const getUser = new GetUserService();
-    const { avatar_url, name } = await getUser.execute(github_login);
+    const { avatar_url, name } = await getUser.execute({
+      username: github_login,
+    });
 
     const hashedPassword = await hash(password, 8);
 

--- a/src/services/CreateTeacherService.ts
+++ b/src/services/CreateTeacherService.ts
@@ -5,6 +5,7 @@ import Teacher from '../models/Teacher';
 import GetUserService from './GetUserService';
 
 interface CreateTeacherRequest {
+  github_id: number;
   email: string;
   github_login: string;
   password: string;
@@ -12,6 +13,7 @@ interface CreateTeacherRequest {
 
 class CreateTeacherService {
   async execute({
+    github_id,
     email,
     github_login,
     password,
@@ -34,6 +36,7 @@ class CreateTeacherService {
     const hashedPassword = await hash(password, 8);
 
     const teacher = teachersRepository.create({
+      github_id,
       avatar_url,
       email,
       github_login,

--- a/src/services/GetDailyCommitsService.ts
+++ b/src/services/GetDailyCommitsService.ts
@@ -8,6 +8,7 @@ interface Commit {
     name: string;
     url: string;
   };
+  sha: string;
   message: string;
   additions: number;
   deletions: number;
@@ -60,9 +61,10 @@ class GetDailyCommitsService {
             } catch (error) {
               throw new AppError('Unable to obtain stats commit', 500);
             }
-            const { stats } = response.data;
+            const { stats, sha } = response.data;
 
             newCommits.push({
+              sha,
               repository: item.repo,
               message: commit.message,
               additions: stats.additions,

--- a/src/services/GetLanguagesService.ts
+++ b/src/services/GetLanguagesService.ts
@@ -28,6 +28,7 @@ class GetLanguagesService {
       try {
         response = await api.get(`/repos/${full_name}/languages`);
       } catch (error) {
+        console.log(error);
         throw new AppError(`Unable to obtain ${full_name} languages.`, 500);
       }
       const languages = response.data;

--- a/src/services/GetLanguagesService.ts
+++ b/src/services/GetLanguagesService.ts
@@ -28,7 +28,6 @@ class GetLanguagesService {
       try {
         response = await api.get(`/repos/${full_name}/languages`);
       } catch (error) {
-        console.log(error);
         throw new AppError(`Unable to obtain ${full_name} languages.`, 500);
       }
       const languages = response.data;

--- a/src/services/GetProfileService.ts
+++ b/src/services/GetProfileService.ts
@@ -7,7 +7,9 @@ class GetProfileService {
     const getUserService = new GetUserService();
     const getRepositoriesService = new GetRepositoriesService();
 
-    const { avatar_url, github_login } = await getUserService.execute(username);
+    const { avatar_url, github_login } = await getUserService.execute({
+      username,
+    });
     const repositories = await getRepositoriesService.execute(username);
 
     return {

--- a/src/services/GetRepositoriesService.ts
+++ b/src/services/GetRepositoriesService.ts
@@ -14,6 +14,7 @@ class GetRepositoriesService {
 
     repositories = repositories.map(item => {
       const {
+        id,
         name,
         full_name,
         description,
@@ -23,6 +24,7 @@ class GetRepositoriesService {
       } = item;
 
       return {
+        id,
         name,
         full_name,
         description,

--- a/src/services/GetRepositoriesService.ts
+++ b/src/services/GetRepositoriesService.ts
@@ -24,7 +24,7 @@ class GetRepositoriesService {
       } = item;
 
       return {
-        id,
+        id: String(id),
         name,
         full_name,
         description,

--- a/src/services/GetTeacherTokenService.ts
+++ b/src/services/GetTeacherTokenService.ts
@@ -7,11 +7,9 @@ class GetTeacherTokenService {
     const teachersRepository = getRepository(Teacher);
 
     const teacher = await teachersRepository.findOne();
-    if (!teacher) return '';
+    if (!teacher || !teacher.github_token) return '';
 
-    const { github_token } = teacher;
-
-    return decrypt(github_token);
+    return decrypt(teacher.github_token);
   }
 }
 

--- a/src/services/GetTeacherTokenService.ts
+++ b/src/services/GetTeacherTokenService.ts
@@ -7,6 +7,7 @@ class GetTeacherTokenService {
     const teachersRepository = getRepository(Teacher);
 
     const teacher = await teachersRepository.findOne();
+    if (!teacher) return '';
 
     const { github_token } = teacher;
 

--- a/src/services/GetUserDailyReportService.ts
+++ b/src/services/GetUserDailyReportService.ts
@@ -33,7 +33,9 @@ interface Response {
 class GetUserDaily {
   public async execute(username: string): Promise<Response> {
     const getUserService = new GetUserService();
-    const { github_login, avatar_url } = await getUserService.execute(username);
+    const { github_login, avatar_url } = await getUserService.execute({
+      username,
+    });
 
     const getDailyCommitsService = new GetDailyCommitsService();
     const { new_commits, commits } = await getDailyCommitsService.execute(

--- a/src/services/GetUserDailyReportService.ts
+++ b/src/services/GetUserDailyReportService.ts
@@ -7,7 +7,10 @@ interface Commit {
     name: string;
     url: string;
   };
+  sha: string;
   message: string;
+  additions: number;
+  deletions: number;
 }
 
 interface Response {

--- a/src/services/GetUserService.ts
+++ b/src/services/GetUserService.ts
@@ -1,23 +1,41 @@
 import api from './api';
 import { catchGitHubNotFound } from '../utils/exceptions';
+import AppError from '../errors/AppError';
+
+interface Request {
+  username?: string;
+  github_id?: string;
+}
 
 interface Response {
+  github_id: string;
   github_login: string;
   avatar_url: string;
   name: string;
 }
 
 class GetUserService {
-  public async execute(username: string): Promise<Response> {
+  public async execute({ username, github_id }: Request): Promise<Response> {
     let response;
-    try {
-      response = await api.get(`/users/${username}`);
-    } catch (error) {
-      throw catchGitHubNotFound(error);
+    if (username) {
+      try {
+        response = await api.get(`/users/${username}`);
+      } catch (error) {
+        throw catchGitHubNotFound(error);
+      }
+    } else if (github_id) {
+      try {
+        response = await api.get(`/user/${github_id}`);
+      } catch (error) {
+        throw catchGitHubNotFound(error);
+      }
+    } else {
+      throw new AppError('Github Login or Github ID is missing', 400);
     }
-    const { login, avatar_url, name } = response.data;
+    const { id, login, avatar_url, name } = response.data;
 
     return {
+      github_id: id,
       github_login: login,
       avatar_url,
       name,

--- a/src/services/GetUserService.ts
+++ b/src/services/GetUserService.ts
@@ -8,7 +8,7 @@ interface Request {
 }
 
 interface Response {
-  github_id: number;
+  github_id: string;
   github_login: string;
   avatar_url: string;
   name: string;
@@ -35,7 +35,7 @@ class GetUserService {
     const { id, login, avatar_url, name } = response.data;
 
     return {
-      github_id: id,
+      github_id: String(id),
       github_login: login,
       avatar_url,
       name,

--- a/src/services/GetUserService.ts
+++ b/src/services/GetUserService.ts
@@ -4,11 +4,11 @@ import AppError from '../errors/AppError';
 
 interface Request {
   username?: string;
-  github_id?: string;
+  github_id?: number;
 }
 
 interface Response {
-  github_id: string;
+  github_id: number;
   github_login: string;
   avatar_url: string;
   name: string;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,16 +1,24 @@
 import axios from 'axios';
 import GetTeacherTokenService from './GetTeacherTokenService';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useGlobal: any = global;
+
 const api = axios.create({
   baseURL: 'https://api.github.com',
 });
 
 api.interceptors.request.use(async config => {
-  const getTeacherToken = new GetTeacherTokenService();
-  const token = await getTeacherToken.execute();
+  if (!useGlobal.teacherToken) {
+    const getTeacherToken = new GetTeacherTokenService();
+    const token = await getTeacherToken.execute();
 
-  if (token) {
-    config.headers.authorization = `token ${token}`;
+    if (token) {
+      useGlobal.teacherToken = token;
+    }
+  }
+  if (useGlobal.teacherToken) {
+    config.headers.authorization = `token ${useGlobal.teacherToken}`;
   }
 
   return config;

--- a/src/utils/exceptions.ts
+++ b/src/utils/exceptions.ts
@@ -2,6 +2,8 @@ import { AxiosError } from 'axios';
 import AppError from '../errors/AppError';
 
 const catchGitHubNotFound = (error: AxiosError): AppError => {
+  console.log('error', error);
+
   if (error.response) {
     const { data, status } = error.response;
 


### PR DESCRIPTION
#### Qual o objetivo dessa Pull Request?

Permitir que o cadastro dos id's do github de Commits, Students, Teachers e Repositories fossem adicionados. Uma vez que o github_login e nomes de referência podem mudar, então é importante manter o id para que a informação possa ser atualizada sempre.
Adicionalmente, houve uma mudança na forma em que o token do professor era obtido, ao invés de pedir sempre ao BD um token, agora o token é guardado no objeto global para que ele não fique utilizando repetidamente o banco de dados.

#### O que foi feito?

- Foram adicionados os campos "sha" em Commits e github_id em Students, Teachers e Repositories para salvar o id do github no banco de dados. 
- Todos os services de criação foram alterados para necessitar o recebimento dos seus id's.
- Os Controllers de Student e Teacher foram modificados para obter o id do aluno ou professor provido no body.
- O GetUserService foi atualizado para permitir a busca de um usuário por username ou por id.
- Objeto global utilizado no interceptor da api.