### PR TITLE
Rota para obtenção de Relatórios em um período.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,8 @@
                 "ts": "never"
             }
             ],
-        "no-param-reassign": "off"
+        "no-param-reassign": "off",
+        "no-restricted-syntax": "off"
 	  },
 	  "settings": {
 	    "import/resolver": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,8 @@
             }
             ],
         "no-param-reassign": "off",
-        "no-restricted-syntax": "off"
+        "no-restricted-syntax": "off",
+        "no-await-in-loop": "off"
 	  },
 	  "settings": {
 	    "import/resolver": {

--- a/src/controllers/StudentController.ts
+++ b/src/controllers/StudentController.ts
@@ -5,6 +5,7 @@ import GetUserService from '../services/GetUserService';
 import GetProfileService from '../services/GetProfileService';
 import GetLanguagesService from '../services/GetLanguagesService';
 import CreateStudentService from '../services/CreateStudentService';
+import GetPeriodStudentDailyReportsService from '../services/GetPeriodStudentDailyReportsService';
 
 class StudentController {
   static async store(request: Request, response: Response): Promise<Response> {
@@ -36,6 +37,24 @@ class StudentController {
     });
 
     return response.json(student);
+  }
+
+  static async show(request: Request, response: Response): Promise<Response> {
+    const schema = yup.object().shape({
+      since: yup.string().required('Since date string is required.'),
+      until: yup.string(),
+    });
+    await schema.validate(request.query);
+
+    const { since, until } = request.query;
+
+    const getPeriodStudentDailyReport = new GetPeriodStudentDailyReportsService();
+    const studentDailyReport = await getPeriodStudentDailyReport.execute(
+      String(since),
+      String(until),
+    );
+
+    return response.json(studentDailyReport);
   }
 }
 

--- a/src/repositories/StudentDailyReportsRepository.ts
+++ b/src/repositories/StudentDailyReportsRepository.ts
@@ -7,8 +7,8 @@ class StudentDailyReportsRepository extends Repository<StudentDailyReport> {
   public async findByPeriod(
     since: Date,
     until: Date,
-  ): Promise<StudentDailyReport | null> {
-    const findStudentDailyReport = await this.findOne({
+  ): Promise<StudentDailyReport[] | null> {
+    const findStudentDailyReport = await this.find({
       where: { created_at: Between(since, until) },
     });
 

--- a/src/repositories/StudentDailyReportsRepository.ts
+++ b/src/repositories/StudentDailyReportsRepository.ts
@@ -5,11 +5,15 @@ import StudentDailyReport from '../models/StudentDailyReport';
 @EntityRepository(StudentDailyReport)
 class StudentDailyReportsRepository extends Repository<StudentDailyReport> {
   public async findByPeriod(
+    student_id: string,
     since: Date,
     until: Date,
   ): Promise<StudentDailyReport[] | null> {
     const findStudentDailyReport = await this.find({
-      where: { created_at: Between(since, until) },
+      where: {
+        created_at: Between(since, until),
+        student_id,
+      },
     });
 
     return findStudentDailyReport || null;

--- a/src/repositories/StudentDailyReportsRepository.ts
+++ b/src/repositories/StudentDailyReportsRepository.ts
@@ -1,0 +1,19 @@
+import { EntityRepository, Repository, Between } from 'typeorm';
+
+import StudentDailyReport from '../models/StudentDailyReport';
+
+@EntityRepository(StudentDailyReport)
+class StudentDailyReportsRepository extends Repository<StudentDailyReport> {
+  public async findByPeriod(
+    since: Date,
+    until: Date,
+  ): Promise<StudentDailyReport | null> {
+    const findStudentDailyReport = await this.findOne({
+      where: { created_at: Between(since, until) },
+    });
+
+    return findStudentDailyReport || null;
+  }
+}
+
+export default StudentDailyReportsRepository;

--- a/src/routes/student.routes.ts
+++ b/src/routes/student.routes.ts
@@ -5,5 +5,6 @@ import StudentController from '../controllers/StudentController';
 const studentRouter = Router();
 
 studentRouter.post('/', StudentController.store);
+studentRouter.get('/:username/reports', StudentController.index);
 
 export default studentRouter;

--- a/src/services/GetPeriodStudentDailyReportsService.ts
+++ b/src/services/GetPeriodStudentDailyReportsService.ts
@@ -1,5 +1,17 @@
-import { getCustomRepository } from 'typeorm';
+import { getCustomRepository, getRepository } from 'typeorm';
 import StudentDailyReportsRepository from '../repositories/StudentDailyReportsRepository';
+import Commit from '../models/Commit';
+
+interface CommitResponse {
+  repository: {
+    name: string;
+    url: string;
+  };
+  sha: string;
+  message: string;
+  additions: number;
+  deletions: number;
+}
 
 interface Response {
   new_interactions: number;
@@ -12,17 +24,22 @@ interface Response {
   additions: number;
   deletions: number;
   created_at: string;
+  commits: CommitResponse[];
 }
 
 class GetPeriodStudentDailyReportsService {
-  public async execute(since: string, until: string): Promise<Response> {
-    const sinceDate = new Date(String(since));
-    const untilDate = until ? new Date(String(until)) : new Date();
+  public async execute(
+    student_id: string,
+    since: string,
+    until: string,
+  ): Promise<Response> {
+    const sinceDate = new Date(since);
+    const untilDate = until !== 'undefined' ? new Date(until) : new Date();
 
     const reportsRepository = getCustomRepository(
       StudentDailyReportsRepository,
     );
-    const reports = await reportsRepository.findByPeriod(sinceDate, untilDate);
+    const commitRepository = getRepository(Commit);
 
     const finalPeriodReport: Response = {
       additions: 0,
@@ -35,9 +52,15 @@ class GetPeriodStudentDailyReportsService {
       new_prs: 0,
       new_repositories: 0,
       new_stars: 0,
+      commits: [],
     };
 
-    reports.forEach(report => {
+    const reports = await reportsRepository.findByPeriod(
+      student_id,
+      sinceDate,
+      untilDate,
+    );
+    for (const report of reports) {
       finalPeriodReport.additions += report.additions;
       finalPeriodReport.deletions += report.deletions;
       finalPeriodReport.new_commits += report.new_commits;
@@ -47,7 +70,27 @@ class GetPeriodStudentDailyReportsService {
       finalPeriodReport.new_prs += report.new_prs;
       finalPeriodReport.new_repositories += report.new_repositories;
       finalPeriodReport.new_stars += report.new_stars;
-    });
+
+      const commits = await commitRepository.find({
+        student_daily_report_id: report.id,
+      });
+
+      const commitsResponse: CommitResponse[] = commits.map(commit => ({
+        sha: commit.sha,
+        additions: commit.additions,
+        deletions: commit.deletions,
+        message: commit.message,
+        repository: {
+          name: commit.repository.name,
+          url: commit.repository.html_url,
+        },
+      }));
+
+      finalPeriodReport.commits = [
+        ...finalPeriodReport.commits,
+        ...commitsResponse,
+      ];
+    }
 
     return finalPeriodReport;
   }

--- a/src/services/GetPeriodStudentDailyReportsService.ts
+++ b/src/services/GetPeriodStudentDailyReportsService.ts
@@ -1,0 +1,56 @@
+import { getCustomRepository } from 'typeorm';
+import StudentDailyReportsRepository from '../repositories/StudentDailyReportsRepository';
+
+interface Response {
+  new_interactions: number;
+  new_forks: number;
+  new_stars: number;
+  new_repositories: number;
+  new_prs: number;
+  new_issues: number;
+  new_commits: number;
+  additions: number;
+  deletions: number;
+  created_at: string;
+}
+
+class GetPeriodStudentDailyReportsService {
+  public async execute(since: string, until: string): Promise<Response> {
+    const sinceDate = new Date(String(since));
+    const untilDate = until ? new Date(String(until)) : new Date();
+
+    const reportsRepository = getCustomRepository(
+      StudentDailyReportsRepository,
+    );
+    const reports = await reportsRepository.findByPeriod(sinceDate, untilDate);
+
+    const finalPeriodReport: Response = {
+      additions: 0,
+      deletions: 0,
+      created_at: new Date().toISOString(),
+      new_commits: 0,
+      new_forks: 0,
+      new_interactions: 0,
+      new_issues: 0,
+      new_prs: 0,
+      new_repositories: 0,
+      new_stars: 0,
+    };
+
+    reports.forEach(report => {
+      finalPeriodReport.additions += report.additions;
+      finalPeriodReport.deletions += report.deletions;
+      finalPeriodReport.new_commits += report.new_commits;
+      finalPeriodReport.new_forks += report.new_forks;
+      finalPeriodReport.new_interactions += report.new_interactions;
+      finalPeriodReport.new_issues += report.new_issues;
+      finalPeriodReport.new_prs += report.new_prs;
+      finalPeriodReport.new_repositories += report.new_repositories;
+      finalPeriodReport.new_stars += report.new_stars;
+    });
+
+    return finalPeriodReport;
+  }
+}
+
+export default GetPeriodStudentDailyReportsService;


### PR DESCRIPTION
#### Qual o objetivo dessa Pull Request?

Adicionar uma rota para que os relatórios de certo período de um estudante cadastrado possam ser obtidos.

#### O que foi feito?
Foi criado um método index no StudentController que é responsável por obter um relatório geral de um período.

#### Como pode ser manualmente testado?
Basta realizar um requisição GET na rota `/student/davigsousa/reports`. Essa rota pode receber dois parâmetros na query, são eles:
- since: é uma data em string, preferencialmente do tipo ISO, significando o início do período que quer ser observado (obrigatório).
- until: é uma data em string, preferencialmente do tipo ISO, significando o final do período que quer ser observado, caso esse parâmetro não seja utilizado o seu valor padrão é o dia atual.

##### Exemplo de resposta:
`GET /student/davigsousa/reports?since=2020-10-02T03:00:00.000Z`
```json
{
  "additions": 0,
  "deletions": 0,
  "created_at": "2020-10-10T16:43:10.264Z",
  "new_commits": 0,
  "new_forks": 0,
  "new_interactions": 0,
  "new_issues": 0,
  "new_prs": 0,
  "new_repositories": 0,
  "new_stars": 0,
  "commits": []
}
```

