### PR TITLE
Crawl Inicial do Spot assim que é Adicionado ao sistema

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,9 +22,11 @@ class App {
 
   public queueProvider: QueueProvider;
 
-  public studentsProcessRequester: Worker;
+  public spotsProcessRequester: Worker;
 
-  public studentProcessor: Worker;
+  public spotsProcessor: Worker;
+
+  public initalSpotsProcessRequester: Worker;
 
   constructor() {
     this.express = express();
@@ -68,11 +70,11 @@ class App {
   }
 
   private workers(): void {
-    this.studentsProcessRequester = new Worker(
+    this.spotsProcessRequester = new Worker(
       'spot-process-requester',
       RequestSpotsProcessProcessor,
     );
-    this.studentProcessor = new Worker('spot-processor', ProcessSpotProcessor);
+    this.spotsProcessor = new Worker('spot-processor', ProcessSpotProcessor);
   }
 
   private routes(): void {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import errorHandlerMiddleware from './middlewares/errorHandlerMiddleware';
 import BullQueueProvider from './providers/queue/implementations/BullQueueProvider';
 import RequestSpotsProcessProcessor from './workers/RequestSpotsProcess/RequestSpotsProcessProcessor';
 import ProcessSpotProcessor from './workers/ProcessSpot/ProcessSpotProcessor';
+import InitalSpotProcessRequester from './workers/InitalSpotProcessRequester/InitalSpotProcessRequester';
 import { QueueProvider } from './providers/queue/QueueProvider';
 import './database';
 
@@ -66,6 +67,9 @@ class App {
   private queues(): void {
     this.queueProvider.register({ queueName: 'spot-process-requester' });
     this.queueProvider.register({ queueName: 'spot-processor' });
+    this.queueProvider.register({
+      queueName: 'initial-spot-process-requester',
+    });
     this.queueProvider.setUI();
   }
 
@@ -75,6 +79,10 @@ class App {
       RequestSpotsProcessProcessor,
     );
     this.spotsProcessor = new Worker('spot-processor', ProcessSpotProcessor);
+    this.initalSpotsProcessRequester = new Worker(
+      'initial-spot-process-requester',
+      InitalSpotProcessRequester,
+    );
   }
 
   private routes(): void {

--- a/backend/src/database/migrations/1606565789215-AddTakenAtOnCommit.ts
+++ b/backend/src/database/migrations/1606565789215-AddTakenAtOnCommit.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export default class AddTakenAtOnCommit1606565789215
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'commits',
+      new TableColumn({
+        name: 'taken_at',
+        type: 'timestamp',
+        isNullable: false,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('commits', 'taken_at');
+  }
+}

--- a/backend/src/models/Commit.ts
+++ b/backend/src/models/Commit.ts
@@ -40,6 +40,9 @@ class Commit {
 
   @UpdateDateColumn()
   updated_at: Date;
+
+  @Column('timestamp')
+  taken_at: Date;
 }
 
 export default Commit;

--- a/backend/src/providers/queue/QueueProvider.ts
+++ b/backend/src/providers/queue/QueueProvider.ts
@@ -1,12 +1,8 @@
 interface SpotRequest {
-  spot_id: string;
-  since: string;
-  until: string;
-  github_name: string;
-}
-
-interface InitalSpotRequest {
-  spot_id: string;
+  spot_id?: string;
+  since?: string;
+  until?: string;
+  github_name?: string;
 }
 
 interface addJobRequest {
@@ -28,10 +24,4 @@ interface QueueProvider {
   setUI(): void;
 }
 
-export {
-  QueueProvider,
-  addJobRequest,
-  registerQueueRequest,
-  SpotRequest,
-  InitalSpotRequest,
-};
+export { QueueProvider, addJobRequest, registerQueueRequest, SpotRequest };

--- a/backend/src/providers/queue/QueueProvider.ts
+++ b/backend/src/providers/queue/QueueProvider.ts
@@ -5,6 +5,10 @@ interface SpotRequest {
   github_name: string;
 }
 
+interface InitalSpotRequest {
+  spot_id: string;
+}
+
 interface addJobRequest {
   queueName: string;
   jobName: string;
@@ -24,4 +28,10 @@ interface QueueProvider {
   setUI(): void;
 }
 
-export { QueueProvider, addJobRequest, registerQueueRequest, SpotRequest };
+export {
+  QueueProvider,
+  addJobRequest,
+  registerQueueRequest,
+  SpotRequest,
+  InitalSpotRequest,
+};

--- a/backend/src/services/Spot/CreateSpotService.ts
+++ b/backend/src/services/Spot/CreateSpotService.ts
@@ -4,6 +4,7 @@ import Spot from '../../models/Spot';
 import { AppError } from '../../errors/AppError';
 import api from '../githubApi/GraphQLApi';
 import Repository from '../../models/Repository';
+import { queueProvider } from '../../app';
 
 interface Request {
   manager_id: string;
@@ -132,6 +133,17 @@ class CreateSpotService {
         return parsedRepository;
       },
     );
+
+    queueProvider.add({
+      job: {
+        spot_id: spot.id,
+      },
+      jobName: `${spot.github_login} process initial request`,
+      queueName: 'initial-spot-process-requester',
+      opts: {
+        removeOnComplete: false,
+      },
+    });
 
     return { github_login, avatar_url, repositories: repositoriesReponse };
   }

--- a/backend/src/services/Spot/GetInteractionsVolumeService.ts
+++ b/backend/src/services/Spot/GetInteractionsVolumeService.ts
@@ -15,7 +15,7 @@ interface Data {
 }
 
 interface DataBaseRequest {
-  created_at: Date;
+  taken_at: Date;
   new_interactions: number;
 }
 
@@ -36,20 +36,20 @@ class GetInteractionsVolumeService {
 
     const dailyReports = await dailyReportRepository.find({
       where: {
-        created_at: Between(since, until),
+        taken_at: Between(since, until),
         spot_id: spot.id,
       },
-      select: ['created_at', 'new_interactions'],
+      select: ['taken_at', 'new_interactions'],
       order: {
-        created_at: 'ASC',
+        taken_at: 'ASC',
       },
     });
 
     const parsedData = dailyReports.map(
-      ({ created_at, new_interactions }: DataBaseRequest) => {
+      ({ taken_at, new_interactions }: DataBaseRequest) => {
         return {
           value: new_interactions,
-          date: created_at,
+          date: taken_at,
         };
       },
     );

--- a/backend/src/services/Spot/GetLinesVolumeService.ts
+++ b/backend/src/services/Spot/GetLinesVolumeService.ts
@@ -16,7 +16,7 @@ interface Data {
 }
 
 interface DataBaseRequest {
-  created_at: Date;
+  taken_at: Date;
   additions: number;
   deletions: number;
 }
@@ -38,21 +38,21 @@ class GetLinesVolumeService {
 
     const dailyReports = await dailyReportRepository.find({
       where: {
-        created_at: Between(since, until),
+        taken_at: Between(since, until),
         spot_id: spot.id,
       },
-      select: ['created_at', 'additions', 'deletions'],
+      select: ['taken_at', 'additions', 'deletions'],
       order: {
-        created_at: 'ASC',
+        taken_at: 'ASC',
       },
     });
 
     const parsedData = dailyReports.map(
-      ({ created_at, additions, deletions }: DataBaseRequest) => {
+      ({ taken_at, additions, deletions }: DataBaseRequest) => {
         return {
           gains: additions,
           loss: deletions,
-          date: created_at,
+          date: taken_at,
         };
       },
     );

--- a/backend/src/services/Spot/GetSpotReportService.ts
+++ b/backend/src/services/Spot/GetSpotReportService.ts
@@ -62,7 +62,7 @@ class GetSpotReportService {
     const commits = await commitRepository.find({
       where: {
         spot_id: id,
-        created_at: Between(since, until),
+        taken_at: Between(since, until),
       },
     });
 

--- a/backend/src/workers/InitalSpotProcessRequester/InitalSpotProcessRequester.ts
+++ b/backend/src/workers/InitalSpotProcessRequester/InitalSpotProcessRequester.ts
@@ -1,0 +1,78 @@
+import { Job } from 'bullmq';
+import { getRepository } from 'typeorm';
+import { queueProvider } from '../../app';
+import Spot from '../../models/Spot';
+import { InitalSpotRequest } from '../../providers/queue/QueueProvider';
+import { AppError } from '../../errors/AppError';
+
+const InitalSpotProcessRequester = async (
+  job: Job<InitalSpotRequest>,
+): Promise<void> => {
+  const { spot_id } = job.data;
+  const spotsRepository = getRepository(Spot);
+
+  const spot = await spotsRepository.findOne({
+    where: {
+      id: spot_id,
+    },
+  });
+
+  if (!spot) {
+    throw new AppError('Spot not registered');
+  }
+
+  const today = new Date();
+  const since = new Date(
+    Date.UTC(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - 1,
+      0,
+      0,
+      0,
+      0,
+    ),
+  );
+  const until = new Date(
+    Date.UTC(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - 1,
+      23,
+      59,
+      59,
+      999,
+    ),
+  );
+
+  for (let day = 0; day < 30; day += 1) {
+    console.log(
+      `Starting spot crawl request at ${since.toISOString()} - ${until.toISOString()}`,
+    );
+
+    console.log(
+      `Request spot ${spot.github_login} process at ${since.toISOString()}`,
+    );
+
+    queueProvider.add({
+      job: {
+        spot_id: spot.id,
+        since: since.toISOString(),
+        until: until.toISOString(),
+        github_name: spot.github_login,
+      },
+      jobName: `${
+        spot.github_login
+      } process request at ${since.toISOString()} - ${until.toISOString()}`,
+      queueName: 'spot-processor',
+      opts: {
+        removeOnComplete: false,
+      },
+    });
+
+    since.setDate(since.getDate() - 1);
+    until.setDate(until.getDate() - 1);
+  }
+};
+
+export default InitalSpotProcessRequester;

--- a/backend/src/workers/InitalSpotProcessRequester/InitalSpotProcessRequester.ts
+++ b/backend/src/workers/InitalSpotProcessRequester/InitalSpotProcessRequester.ts
@@ -2,11 +2,11 @@ import { Job } from 'bullmq';
 import { getRepository } from 'typeorm';
 import { queueProvider } from '../../app';
 import Spot from '../../models/Spot';
-import { InitalSpotRequest } from '../../providers/queue/QueueProvider';
+import { SpotRequest } from '../../providers/queue/QueueProvider';
 import { AppError } from '../../errors/AppError';
 
 const InitalSpotProcessRequester = async (
-  job: Job<InitalSpotRequest>,
+  job: Job<SpotRequest>,
 ): Promise<void> => {
   const { spot_id } = job.data;
   const spotsRepository = getRepository(Spot);

--- a/backend/src/workers/ProcessSpot/ProcessSpotProcessor.ts
+++ b/backend/src/workers/ProcessSpot/ProcessSpotProcessor.ts
@@ -66,6 +66,7 @@ const ProcessSpotProcessor = async (job: Job<SpotRequest>): Promise<void> => {
       commit_url,
       repository_name: repository.name,
       repository_url: repository.url,
+      taken_at: until,
     });
 
     await commitRepository.save(spotCommit);

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -308,13 +308,9 @@ const Profile: React.FC = () => {
                 isLoading={loadingCommits}
                 items={commits}
                 mapItem={item => {
-                  const repositoryName = item.repository
-                    ? item.repository.name
-                    : 'Repositório indisponível';
                   
-
                   return {
-                    label: repositoryName,
+                    label: item.repository_name,
                     subLabel: item.message,
                     link: item.commit_url,
                   };


### PR DESCRIPTION

#### Que problema está resolvendo?

Atualmente, após o cadastro de um spot, não havia dado algum para o mesmo. Então, assim que o usuário é cadastrado no sistema, é criado 1 thread de coletas para os ultimos 30 dias
